### PR TITLE
Fix/exposes handlebar parser without html

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -75,5 +75,7 @@ const mixedParser = parser.configure({
     })
 });
 const handlebarsLanguage = language.LRLanguage.define({ parser: mixedParser });
+const handlebarsPureLanguage = language.LRLanguage.define({ parser });
 
 exports.handlebarsLanguage = handlebarsLanguage;
+exports.handlebarsPureLanguage = handlebarsPureLanguage;

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -75,6 +75,10 @@ const mixedParser = parser.configure({
     })
 });
 const handlebarsLanguage = language.LRLanguage.define({ parser: mixedParser });
+/**
+ * Handlebar language exporting a parser without html mixed language
+ * Allows you to add your own client side
+ */
 const handlebarsPureLanguage = language.LRLanguage.define({ parser });
 
 exports.handlebarsLanguage = handlebarsLanguage;

--- a/dist/index.d.cts
+++ b/dist/index.d.cts
@@ -1,3 +1,4 @@
 import { LRLanguage } from "@codemirror/language";
 declare const handlebarsLanguage: LRLanguage;
-export { handlebarsLanguage };
+declare const handlebarsPureLanguage: LRLanguage;
+export { handlebarsLanguage, handlebarsPureLanguage };

--- a/dist/index.d.cts
+++ b/dist/index.d.cts
@@ -1,4 +1,8 @@
 import { LRLanguage } from "@codemirror/language";
 declare const handlebarsLanguage: LRLanguage;
+/**
+ * Handlebar language exporting a parser without html mixed language
+ * Allows you to add your own client side
+ */
 declare const handlebarsPureLanguage: LRLanguage;
 export { handlebarsLanguage, handlebarsPureLanguage };

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,3 +1,4 @@
 import { LRLanguage } from "@codemirror/language";
 declare const handlebarsLanguage: LRLanguage;
-export { handlebarsLanguage };
+declare const handlebarsPureLanguage: LRLanguage;
+export { handlebarsLanguage, handlebarsPureLanguage };

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,8 @@
 import { LRLanguage } from "@codemirror/language";
 declare const handlebarsLanguage: LRLanguage;
+/**
+ * Handlebar language exporting a parser without html mixed language
+ * Allows you to add your own client side
+ */
 declare const handlebarsPureLanguage: LRLanguage;
 export { handlebarsLanguage, handlebarsPureLanguage };

--- a/dist/index.js
+++ b/dist/index.js
@@ -71,5 +71,6 @@ const mixedParser = parser.configure({
     })
 });
 const handlebarsLanguage = LRLanguage.define({ parser: mixedParser });
+const handlebarsPureLanguage = LRLanguage.define({ parser });
 
-export { handlebarsLanguage };
+export { handlebarsLanguage, handlebarsPureLanguage };

--- a/dist/index.js
+++ b/dist/index.js
@@ -71,6 +71,10 @@ const mixedParser = parser.configure({
     })
 });
 const handlebarsLanguage = LRLanguage.define({ parser: mixedParser });
+/**
+ * Handlebar language exporting a parser without html mixed language
+ * Allows you to add your own client side
+ */
 const handlebarsPureLanguage = LRLanguage.define({ parser });
 
 export { handlebarsLanguage, handlebarsPureLanguage };

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,3 +24,10 @@ const mixedParser = parser.configure({
 })
 
 export const handlebarsLanguage = LRLanguage.define({ parser: mixedParser })
+/**
+ * Handlebar language exporting a parser without html mixed language  
+ * Allows you to add your own client side
+ */
+
+export const handlebarsPureLanguage = LRLanguage.define({ parser });
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,10 +24,10 @@ const mixedParser = parser.configure({
 })
 
 export const handlebarsLanguage = LRLanguage.define({ parser: mixedParser })
+
 /**
  * Handlebar language exporting a parser without html mixed language  
  * Allows you to add your own client side
  */
-
 export const handlebarsPureLanguage = LRLanguage.define({ parser });
 


### PR DESCRIPTION
The lib currently forces clients to use the handlebars language with html.
This PR exposes a new language definition without any mixed language so that clients can add their own (i.e. json)